### PR TITLE
added commands for revving, shooting, and intaking

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -36,6 +36,12 @@ public final class Constants {
 	}
 
     public static final boolean tuningMode = true;
+
+	public static final class AutonConstants {
+		public static LoggedDashboardNumber AUTON_SHOOT_SUBWOOFER_LENGTH_SEC = new LoggedDashboardNumber("Auton/Constants/AUTON_SHOOT_SUBWOOFER_LENGTH_SEC", 1.0);
+		public static LoggedDashboardNumber AUTON_SHOOT_AUTO_AIM_LENGTH_SEC = new LoggedDashboardNumber("Auton/Constants/AUTON_SHOOT_AUTO_AIM_LENGTH_SEC", 1.0);
+	}
+
     public static final LoggedDashboardNumber deadzone = new LoggedDashboardNumber("CONTROLLER_DEADZONE", 0.1);
     
     public static final double deadzone(double input) {

--- a/src/main/java/frc/robot/commands/auton/RevAutoAim.java
+++ b/src/main/java/frc/robot/commands/auton/RevAutoAim.java
@@ -1,0 +1,26 @@
+package frc.robot.commands.auton;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.Intake.Intake;
+import frc.robot.subsystems.Intake.Intake.IntakeState;
+import frc.robot.subsystems.Shooter.Shooter;
+import frc.robot.subsystems.Shooter.Shooter.ShooterState;
+
+public class RevAutoAim extends Command {
+    private final Shooter shooter;
+    private final Intake intake;
+
+    public RevAutoAim(Shooter shooter, Intake intake) {
+        this.shooter = shooter;
+        this.intake = intake;
+        addRequirements(shooter);
+        addRequirements(intake);
+    }
+
+    @Override
+    public void initialize(){
+        intake.setState(IntakeState.IDLE);
+        shooter.setState(ShooterState.AUTO_AIM_REVVING);
+    }
+
+}

--- a/src/main/java/frc/robot/commands/auton/RevSubwoofer.java
+++ b/src/main/java/frc/robot/commands/auton/RevSubwoofer.java
@@ -1,0 +1,26 @@
+package frc.robot.commands.auton;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.Intake.Intake;
+import frc.robot.subsystems.Intake.Intake.IntakeState;
+import frc.robot.subsystems.Shooter.Shooter;
+import frc.robot.subsystems.Shooter.Shooter.ShooterState;
+
+public class RevSubwoofer extends Command {
+    private final Shooter shooter;
+    private final Intake intake;
+
+    public RevSubwoofer(Shooter shooter, Intake intake) {
+        this.shooter = shooter;
+        this.intake = intake;
+        addRequirements(shooter);
+        addRequirements(intake);
+    }
+
+    @Override
+    public void initialize(){
+        intake.setState(IntakeState.IDLE);
+        shooter.setState(ShooterState.SUBWOOFER_REVVING);
+    }
+
+}

--- a/src/main/java/frc/robot/commands/auton/ShootAutoAim.java
+++ b/src/main/java/frc/robot/commands/auton/ShootAutoAim.java
@@ -2,37 +2,41 @@ package frc.robot.commands.auton;
 
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.Constants;
 import frc.robot.subsystems.Intake.Intake;
 import frc.robot.subsystems.Intake.Intake.IntakeState;
 import frc.robot.subsystems.Shooter.Shooter;
 import frc.robot.subsystems.Shooter.Shooter.ShooterState;
 
-public class StartShoot extends Command {
+public class ShootAutoAim extends Command {
     private final Shooter shooter;
     private final Intake intake;
     private double startTime;
 
-    public StartShoot(Shooter shooter, Intake intake) {
+    public ShootAutoAim(Shooter shooter, Intake intake) {
         this.shooter = shooter;
         this.intake = intake;
+        addRequirements(shooter);
+        addRequirements(intake);
     }
 
     @Override
     public void initialize(){
         this.startTime = Timer.getFPGATimestamp();
-        shooter.setState(ShooterState.SUBWOOFER_REVVING);
     }
 
     @Override
     public boolean isFinished() {
-        if (Timer.getFPGATimestamp() - this.startTime > 3.0) {
+        double length = Constants.AutonConstants.AUTON_SHOOT_AUTO_AIM_LENGTH_SEC.get();
+
+        if (Timer.getFPGATimestamp() - this.startTime >= length) {
             shooter.setState(ShooterState.IDLE);
             intake.setState(IntakeState.IDLE);
             return true;
         }
 
-        if (Timer.getFPGATimestamp() - this.startTime > 2.0) {
-            shooter.setState(ShooterState.SUBWOOFER);
+        if (Timer.getFPGATimestamp() - this.startTime < length) {
+            shooter.setState(ShooterState.AUTO_AIM);
             intake.setState(IntakeState.SHOOTING);
         }
 

--- a/src/main/java/frc/robot/commands/auton/ShootSubwoofer.java
+++ b/src/main/java/frc/robot/commands/auton/ShootSubwoofer.java
@@ -1,0 +1,46 @@
+package frc.robot.commands.auton;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.Constants;
+import frc.robot.subsystems.Intake.Intake;
+import frc.robot.subsystems.Intake.Intake.IntakeState;
+import frc.robot.subsystems.Shooter.Shooter;
+import frc.robot.subsystems.Shooter.Shooter.ShooterState;
+
+public class ShootSubwoofer extends Command {
+    private final Shooter shooter;
+    private final Intake intake;
+    private double startTime;
+
+    public ShootSubwoofer(Shooter shooter, Intake intake) {
+        this.shooter = shooter;
+        this.intake = intake;
+        addRequirements(shooter);
+        addRequirements(intake);
+    }
+
+    @Override
+    public void initialize(){
+        this.startTime = Timer.getFPGATimestamp();
+    }
+
+    @Override
+    public boolean isFinished() {
+        double length = Constants.AutonConstants.AUTON_SHOOT_SUBWOOFER_LENGTH_SEC.get();
+
+        if (Timer.getFPGATimestamp() - this.startTime >= length) {
+            shooter.setState(ShooterState.IDLE);
+            intake.setState(IntakeState.IDLE);
+            return true;
+        }
+
+        if (Timer.getFPGATimestamp() - this.startTime < length) {
+            shooter.setState(ShooterState.SUBWOOFER);
+            intake.setState(IntakeState.SHOOTING);
+        }
+
+        return false;
+    }
+
+}

--- a/src/main/java/frc/robot/commands/auton/StartIntake.java
+++ b/src/main/java/frc/robot/commands/auton/StartIntake.java
@@ -9,6 +9,7 @@ public class StartIntake extends Command {
 
     public StartIntake(Intake intake) {
         this.intake = intake;
+        addRequirements(intake);
     }
 
     @Override

--- a/src/main/java/frc/robot/commands/auton/StopIntake.java
+++ b/src/main/java/frc/robot/commands/auton/StopIntake.java
@@ -4,11 +4,12 @@ import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.Intake.Intake;
 import frc.robot.subsystems.Intake.Intake.IntakeState;
 
-public class EndIntake extends Command {
+public class StopIntake extends Command {
     private final Intake intake;
 
-    public EndIntake(Intake intake) {
+    public StopIntake(Intake intake) {
         this.intake = intake;
+        addRequirements(intake);
     }
 
     @Override

--- a/src/main/java/frc/robot/commands/auton/StopShooter.java
+++ b/src/main/java/frc/robot/commands/auton/StopShooter.java
@@ -1,0 +1,20 @@
+package frc.robot.commands.auton;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.Shooter.Shooter;
+import frc.robot.subsystems.Shooter.Shooter.ShooterState;
+
+public class StopShooter extends Command {
+    private final Shooter shooter;
+
+    public StopShooter(Shooter shooter) {
+        this.shooter = shooter;
+        addRequirements(shooter);
+    }
+
+    @Override
+    public void initialize(){
+        shooter.setState(ShooterState.IDLE);
+    }
+
+}


### PR DESCRIPTION
Added the commands for revving, shooting, and intaking.

- The rev commands are instant and DO NOT stop the shooter when the commands are finished. (The shooter will switch from rev mode to shoot mode in pathplanner)
- The shoot commands run the shooter and intake for a specific amount of time, as specified in the live tunable constants, then stop the shooter and intake.
- The StartIntake and StopIntake commands are instant.
- The StopShooter command is instant and will likely not be used, as you should go from Rev -> Shoot, which auto stops after the time. I added it incase we needed if for some reason in the future.